### PR TITLE
fix: ensure resp body

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,10 +57,14 @@ class BunyanESStream extends Writable {
       }
 
       this.push(entry)
-
-      callback()
+      
+      if (callback) {
+        callback()
+      }
     } catch (e) {
-      callback(e)
+      if (callback) {
+        callback(e)
+      }
     }
   }
 
@@ -128,7 +132,7 @@ class BunyanESStream extends Writable {
     }, [])
 
     this.client.bulk({ body }, (err, resp) => {
-      if (resp.body.errors) {
+      if (resp && reap.body && resp.body.errors) {
         for (let i = 0; i < resp.body.items.length; i++) {
           const item = resp.body.items[i]
 
@@ -145,7 +149,9 @@ class BunyanESStream extends Writable {
   _final (callback) {
     this.closed = true
     this.flush()
-    callback()
+    if (callback) {
+      callback()
+    }
   }
 }
 


### PR DESCRIPTION
Ensure that the ES Client resp has a body before calling body.errors
this can occur if this Client fails due to network or other related issues.